### PR TITLE
feat Add line/bar diagram reporting based on a card

### DIFF
--- a/packages/app/src/components/catalog/EntityPage.tsx
+++ b/packages/app/src/components/catalog/EntityPage.tsx
@@ -54,7 +54,7 @@ import { TechDocsAddons } from '@backstage/plugin-techdocs-react';
 import Button from '@mui/material/Button';
 import Grid from '@mui/material/Grid';
 
-import { ScoreCardsView } from '@janus-idp/backstage-plugin-rules';
+import { CardsView } from '@janus-idp/backstage-plugin-rules';
 
 const techdocsContent = (
   <EntityTechdocsContent>
@@ -197,7 +197,7 @@ const websiteEntityPage = (
       {techdocsContent}
     </EntityLayout.Route>
     <EntityLayout.Route path="/rules" title="Scorecard">
-      <ScoreCardsView />
+      <CardsView />
     </EntityLayout.Route>
   </EntityLayout>
 );

--- a/plugins/rules/package.json
+++ b/plugins/rules/package.json
@@ -30,7 +30,6 @@
     "@backstage/core-components": "^0.14.6",
     "@backstage/core-plugin-api": "^1.9.2",
     "@backstage/theme": "^0.5.3",
-    "@kie-tools/yard-editor": "^0.32.0",
     "@material-ui/core": "^4.9.13",
     "@material-ui/icons": "^4.9.1",
     "@material-ui/lab": "^4.0.0-alpha.61",

--- a/plugins/rules/src/api/RulesClient.ts
+++ b/plugins/rules/src/api/RulesClient.ts
@@ -9,10 +9,10 @@ import {
   Card,
   CardConfig,
   CardData,
+  CardResult,
   Job,
   RawData,
   RawDataDetail,
-  ScoreCardResult,
 } from './types';
 
 export class ScoreCardBackendClient implements ScoreCardApi {
@@ -77,7 +77,7 @@ export class ScoreCardBackendClient implements ScoreCardApi {
     return await this.handleResponse(response);
   }
 
-  async listCardResults(): Promise<{ results: ScoreCardResult[] }> {
+  async listCardResults(): Promise<{ results: CardResult[] }> {
     const url = `${await this.getIngestorBaseUrl()}/card/results`;
     const response = await fetch(url, {
       method: 'GET',
@@ -88,7 +88,7 @@ export class ScoreCardBackendClient implements ScoreCardApi {
 
   async listCardResultHistory(
     cardId: number,
-  ): Promise<{ results: ScoreCardResult[] }> {
+  ): Promise<{ results: CardResult[] }> {
     const url = `${await this.getIngestorBaseUrl()}/card/${cardId}/history`;
     const response = await fetch(url, {
       method: 'GET',

--- a/plugins/rules/src/api/api.ts
+++ b/plugins/rules/src/api/api.ts
@@ -4,10 +4,10 @@ import {
   Card,
   CardConfig,
   CardData,
+  CardResult,
   Job,
   RawData,
   RawDataDetail,
-  ScoreCardResult,
 } from './types';
 
 export interface ScoreCardApi {
@@ -17,11 +17,9 @@ export interface ScoreCardApi {
 
   getCardData(cardId: number): Promise<CardData>;
 
-  listCardResults(): Promise<{ results: ScoreCardResult[] }>;
+  listCardResults(): Promise<{ results: CardResult[] }>;
 
-  listCardResultHistory(
-    cardId: number,
-  ): Promise<{ results: ScoreCardResult[] }>;
+  listCardResultHistory(cardId: number): Promise<{ results: CardResult[] }>;
 
   listScoreCards(): Promise<{ results: Card[] }>;
 

--- a/plugins/rules/src/api/index.ts
+++ b/plugins/rules/src/api/index.ts
@@ -1,4 +1,4 @@
-export type { ScoreCardResult } from './types';
+export type { CardResult } from './types';
 export type { ScoreCardBackendClient } from './RulesClient';
 export { scoreCardApiRef } from './api';
 export type { ScoreCardApi } from './api';

--- a/plugins/rules/src/api/types.ts
+++ b/plugins/rules/src/api/types.ts
@@ -1,8 +1,12 @@
-export type ScoreCardResult = {
+export type ScoreMeasureValue = {
+  score: number;
+};
+
+export type CardResult = {
   cardId: number;
   runTime: number;
   status: string;
-  measureValue: number;
+  measureValue: any;
   measureName: string;
   maxValue: number;
   yaml: string;

--- a/plugins/rules/src/components/Cards/CardsView.tsx
+++ b/plugins/rules/src/components/Cards/CardsView.tsx
@@ -9,10 +9,10 @@ import { useRouteRef } from '@backstage/core-plugin-api';
 import Button from '@material-ui/core/Button';
 import Grid from '@material-ui/core/Grid';
 
-import { ScoreCardResult } from '../../api';
+import { CardResult } from '../../api';
 import { rootRouteRef } from '../../routes';
 import { useScoreCards } from '../../useRulesClient';
-import { ScorecardCard } from './ScorecardCard';
+import { CardView } from './Reporting/CardView';
 
 const containerStyle = { width: '100%', height: '100vh' };
 
@@ -43,10 +43,10 @@ export const EmptyCardState = () => {
   );
 };
 type Props = {
-  scorecards: ScoreCardResult[];
+  scorecards: CardResult[];
 };
 
-export const ScoreCardVisualization = ({ scorecards }: Props) => {
+export const CardVisualization = ({ scorecards }: Props) => {
   return (
     <React.Fragment>
       <Grid container spacing={2}>
@@ -57,7 +57,7 @@ export const ScoreCardVisualization = ({ scorecards }: Props) => {
         </Grid>
         {scorecards.map(scorecard => (
           <Grid item xs={4} key={scorecard.measureName}>
-            <ScorecardCard scorecard={scorecard} />
+            <CardView scorecard={scorecard} />
           </Grid>
         ))}
       </Grid>
@@ -65,7 +65,7 @@ export const ScoreCardVisualization = ({ scorecards }: Props) => {
   );
 };
 
-export const ScoreCardsView = () => {
+export const CardsView = () => {
   const { value, loading, error } = useScoreCards();
 
   if (loading) {
@@ -76,5 +76,5 @@ export const ScoreCardsView = () => {
     return <EmptyCardState />;
   }
 
-  return <ScoreCardVisualization scorecards={value || []} />;
+  return <CardVisualization scorecards={value || []} />;
 };

--- a/plugins/rules/src/components/Cards/Reporting/CardView.tsx
+++ b/plugins/rules/src/components/Cards/Reporting/CardView.tsx
@@ -1,0 +1,60 @@
+import React from 'react';
+
+import { CardResult, ScoreMeasureValue } from '../../../api/types';
+import { ChartDataFormer } from './ChartDataFormer';
+import { ReportingCard } from './ReportingCard';
+import { ScorecardCard } from './ScorecardCard';
+
+type Props = {
+  scorecard: CardResult;
+};
+
+enum Type {
+  SCORE,
+  LIST,
+  MAP,
+  VALUE,
+}
+
+function getType(x: any): Type {
+  if ('score' in x) {
+    return Type.SCORE;
+  } else if (Array.isArray(x)) {
+    return Type.LIST;
+  } else if (x instanceof Map) {
+    return Type.MAP;
+  }
+  return Type.VALUE;
+}
+
+export const CardView = ({ scorecard }: Props) => {
+  const measureValue = scorecard.measureValue;
+
+  switch (getType(measureValue)) {
+    case Type.SCORE:
+      return (
+        <ScorecardCard
+          scorecard={scorecard}
+          measureValue={measureValue as ScoreMeasureValue}
+        />
+      );
+    case Type.LIST:
+      return (
+        <ReportingCard
+          scorecard={scorecard}
+          measureValue={new ChartDataFormer().formReportingDataFromList(
+            measureValue as [],
+          )}
+        />
+      );
+    default:
+      return (
+        <ReportingCard
+          scorecard={scorecard}
+          measureValue={new ChartDataFormer().formReportingDataFromMap(
+            measureValue,
+          )}
+        />
+      );
+  }
+};

--- a/plugins/rules/src/components/Cards/Reporting/ChartDataFormer.test.ts
+++ b/plugins/rules/src/components/Cards/Reporting/ChartDataFormer.test.ts
@@ -1,0 +1,42 @@
+import { ChartDataFormer } from './ChartDataFormer';
+import { ChartData } from './types';
+
+describe('Data forming Test', () => {
+  it('Should return data from list', () => {
+    const list: any = [1, 4, -10, 3, 4];
+    const data = new ChartDataFormer().formReportingDataFromList(list);
+
+    expect(data.data.size).toEqual(1);
+    expect(data.maxValue).toEqual(4);
+    expect(data.minValue).toEqual(-10);
+    const value = data.data.get('Value') as ChartData[];
+    expect(value).toEqual([
+      { name: 'Value', x: 0, y: 1 },
+      { name: 'Value', x: 1, y: 4 },
+      { name: 'Value', x: 2, y: -10 },
+      { name: 'Value', x: 3, y: 3 },
+      { name: 'Value', x: 4, y: 4 },
+    ]);
+  });
+
+  it('Should return data from map', () => {
+    const map = new Map<string, number>();
+    map.set('A', 1);
+    map.set('B', 10);
+    map.set('C', -20);
+    map.set('D', 5);
+
+    const data = new ChartDataFormer().formReportingDataFromMap(map);
+
+    expect(data.data.size).toEqual(1);
+    expect(data.maxValue).toEqual(10);
+    expect(data.minValue).toEqual(-20);
+    const value = data.data.get('Value') as ChartData[];
+    expect(value).toEqual([
+      { name: 'Value', x: 'A', y: 1 },
+      { name: 'Value', x: 'B', y: 10 },
+      { name: 'Value', x: 'C', y: -20 },
+      { name: 'Value', x: 'D', y: 5 },
+    ]);
+  });
+});

--- a/plugins/rules/src/components/Cards/Reporting/ChartDataFormer.ts
+++ b/plugins/rules/src/components/Cards/Reporting/ChartDataFormer.ts
@@ -1,0 +1,52 @@
+import { ChartData, ReportingData } from './types';
+
+export class ChartDataFormer {
+  result = new Map<string, ChartData[]>();
+  max: number = 0;
+  min: number = 0;
+
+  formReportingDataFromMap(measureValue: Map<any, number>): ReportingData {
+    this.result.set('Value', []);
+
+    Object.keys(measureValue).forEach(key => {
+      this.manageDataItem(key, measureValue[key]);
+    });
+
+    return {
+      data: this.result,
+      minValue: this.min,
+      maxValue: this.max,
+    };
+  }
+
+  formReportingDataFromList(measureValue: []): ReportingData {
+    let i = 0;
+
+    this.result.set('Value', []);
+    measureValue.forEach(value => {
+      this.manageDataItem(i++, value);
+    });
+
+    return {
+      data: this.result,
+      minValue: this.min,
+      maxValue: this.max,
+    };
+  }
+
+  private manageDataItem(key: any, value: number) {
+    const numberValue = Number(value);
+
+    this.result.get('Value')?.push({
+      name: 'Value',
+      x: key,
+      y: numberValue,
+    });
+    if (this.max < numberValue) {
+      this.max = numberValue;
+    }
+    if (this.min > numberValue) {
+      this.min = numberValue;
+    }
+  }
+}

--- a/plugins/rules/src/components/Cards/Reporting/ReportingCard.tsx
+++ b/plugins/rules/src/components/Cards/Reporting/ReportingCard.tsx
@@ -1,0 +1,92 @@
+import React from 'react';
+
+import { Button, Card, CardActions, CardContent } from '@material-ui/core';
+import {
+  Chart,
+  ChartGroup,
+  ChartLine,
+  ChartVoronoiContainer,
+} from '@patternfly/react-charts';
+import { CodeEditor } from '@patternfly/react-code-editor';
+import { Modal, ModalVariant } from '@patternfly/react-core';
+
+import { CardResult } from '../../../api';
+import { darkStyles, ReportingData } from './types';
+
+type Props = {
+  scorecard: CardResult;
+  measureValue: ReportingData;
+};
+
+export const ReportingCard = ({ scorecard, measureValue }: Props) => {
+  const [isSourceModalOpen, setIsSourceModalOpen] = React.useState(false);
+  const handleSourceModalToggle = (
+    _event: KeyboardEvent | React.MouseEvent,
+  ) => {
+    setIsSourceModalOpen(!isSourceModalOpen);
+  };
+
+  return (
+    <Card style={{ height: '100%', width: '100%' }}>
+      <CardContent>
+        <b>{scorecard.measureName}</b>
+
+        <div className="pf-v5-theme-dark">
+          <Modal
+            className="pf-v5-theme-dark"
+            variant={ModalVariant.medium}
+            title={scorecard.measureName}
+            isOpen={isSourceModalOpen}
+            onClose={handleSourceModalToggle}
+            actions={[]}
+          >
+            <CodeEditor
+              height="400px"
+              isDarkTheme
+              readOnly
+              code={scorecard.yaml}
+              contentEditable={false}
+            />
+          </Modal>
+        </div>
+
+        <div style={darkStyles}>
+          <Chart
+            ariaDesc="Data over time."
+            ariaTitle="Data"
+            containerComponent={
+              <ChartVoronoiContainer
+                labels={({ datum }) => `${datum.name}: ${datum.y}`}
+                constrainToVisibleArea
+              />
+            }
+            legendOrientation="vertical"
+            legendPosition="right"
+            height={280}
+            maxDomain={{ y: measureValue.maxValue }}
+            minDomain={{ y: measureValue.minValue }}
+            name="chart1"
+            padding={{
+              bottom: 30,
+              left: 50,
+              right: 40, // Adjusted to accommodate legend
+              top: 20,
+            }}
+            width={600}
+          >
+            <ChartGroup>
+              {Array.from(measureValue.data.values()).map(g => (
+                <ChartLine data={g} />
+              ))}
+            </ChartGroup>
+          </Chart>
+        </div>
+      </CardContent>
+      <CardActions>
+        <Button size="small" onClick={handleSourceModalToggle}>
+          Source
+        </Button>
+      </CardActions>
+    </Card>
+  );
+};

--- a/plugins/rules/src/components/Cards/Reporting/ScoreCardHistory.tsx
+++ b/plugins/rules/src/components/Cards/Reporting/ScoreCardHistory.tsx
@@ -11,22 +11,16 @@ import {
   ChartThreshold,
   ChartVoronoiContainer,
 } from '@patternfly/react-charts';
+import { Title } from '@patternfly/react-core';
 import { chart_color_orange_300 } from '@patternfly/react-tokens';
 
-import { scoreCardApiRef } from '../../api';
+import { scoreCardApiRef } from '../../../api';
+import { ScoreMeasureValue } from '../../../api/types';
+import { ChartData, darkStyles } from './types';
 
 type Props = {
   cardId: number;
 };
-const darkStyles = {
-  '--pf-v5-chart-global--label--Fill': 'white',
-} as React.CSSProperties;
-
-interface ChartData {
-  name: string;
-  y: number;
-  x: number;
-}
 
 export const ScoreCardHistory = ({ cardId }: Props) => {
   const [scoreCardResults, setScoreCardResults] = useState<ChartData[]>([]);
@@ -55,7 +49,7 @@ export const ScoreCardHistory = ({ cardId }: Props) => {
         scResults.push({
           name: 'Score',
           x: result.runTime,
-          y: result.measureValue,
+          y: (result.measureValue as ScoreMeasureValue).score,
         });
       });
 

--- a/plugins/rules/src/components/Cards/Reporting/ScorecardCard.tsx
+++ b/plugins/rules/src/components/Cards/Reporting/ScorecardCard.tsx
@@ -9,11 +9,13 @@ import {
 import { CodeEditor } from '@patternfly/react-code-editor';
 import { Modal, ModalVariant } from '@patternfly/react-core';
 
-import { ScoreCardResult } from '../../api';
+import { CardResult } from '../../../api';
+import { ScoreMeasureValue } from '../../../api/types';
 import { ScoreCardHistory } from './ScoreCardHistory';
 
 type Props = {
-  scorecard: ScoreCardResult;
+  scorecard: CardResult;
+  measureValue: ScoreMeasureValue;
 };
 
 const darkStyles = {
@@ -21,7 +23,7 @@ const darkStyles = {
   '--pf-v5-chart-donut--label--title--Fill': 'white',
 } as React.CSSProperties;
 
-export const ScorecardCard = ({ scorecard }: Props) => {
+export const ScorecardCard = ({ scorecard, measureValue }: Props) => {
   const [isSourceModalOpen, setIsSourceModalOpen] = React.useState(false);
   const [isHistoryModalOpen, setHistoryModalOpen] = React.useState(false);
 
@@ -37,7 +39,7 @@ export const ScorecardCard = ({ scorecard }: Props) => {
     setHistoryModalOpen(!isHistoryModalOpen);
   };
 
-  function formThresholdData(scoreCard: ScoreCardResult): any[] {
+  function formThresholdData(scoreCard: CardResult): any[] {
     return scoreCard.thresholds.map(threshold => {
       return {
         x: threshold.name,
@@ -46,7 +48,7 @@ export const ScorecardCard = ({ scorecard }: Props) => {
     });
   }
 
-  function formThresholdDataLabels(scoreCard: ScoreCardResult): any[] {
+  function formThresholdDataLabels(scoreCard: CardResult): any[] {
     const map = scoreCard.thresholds.map(threshold => {
       return {
         name: `${threshold.name} threshold from ${threshold.limit}`,
@@ -55,7 +57,7 @@ export const ScorecardCard = ({ scorecard }: Props) => {
     return map;
   }
 
-  function formThresholdValues(scoreCard: ScoreCardResult): any[] {
+  function formThresholdValues(scoreCard: CardResult): any[] {
     return scoreCard.thresholds.map(threshold => {
       return {
         value: threshold.limit - 1,
@@ -114,7 +116,10 @@ export const ScorecardCard = ({ scorecard }: Props) => {
             width={425}
           >
             <ChartDonutUtilization
-              data={{ x: 'Storage capacity', y: scorecard.measureValue }}
+              data={{
+                x: 'Storage capacity',
+                y: measureValue.score,
+              }}
               labels={({ datum }) =>
                 datum.x ? `${datum.x}: ${datum.y}%` : null
               }
@@ -122,7 +127,7 @@ export const ScorecardCard = ({ scorecard }: Props) => {
               legendOrientation="vertical"
               invert
               subTitle={`of ${scorecard.maxValue}`}
-              title={`${scorecard.measureValue}`}
+              title={`${measureValue.score}`}
               themeColor={ChartThemeColor.green}
               thresholds={formThresholdValues(scorecard)}
             />

--- a/plugins/rules/src/components/Cards/Reporting/types.ts
+++ b/plugins/rules/src/components/Cards/Reporting/types.ts
@@ -1,0 +1,17 @@
+import React from 'react';
+
+export type ReportingData = {
+  data: Map<string, ChartData[]>;
+  minValue: number;
+  maxValue: number;
+};
+
+export interface ChartData {
+  name: string;
+  y: number;
+  x: any;
+}
+
+export const darkStyles = {
+  '--pf-v5-chart-global--label--Fill': 'white',
+} as React.CSSProperties;

--- a/plugins/rules/src/components/Cards/index.ts
+++ b/plugins/rules/src/components/Cards/index.ts
@@ -1,3 +1,3 @@
-export { ScoreCardsView } from './ScoreCardsView';
+export { CardsView } from './CardsView';
 export { ScoreCardsTable } from './ScoreCardsTable';
 export { CardForm } from './CardForm';

--- a/plugins/rules/src/components/Home/AkrivisHomeComponent.tsx
+++ b/plugins/rules/src/components/Home/AkrivisHomeComponent.tsx
@@ -18,12 +18,12 @@ import { JobsTable } from '../Jobs';
 export const AkrivisHomeComponent = () => {
   return (
     <Page themeId="tool">
-      <Header title="Welcome to Scorecard" subtitle="Optional subtitle">
+      <Header title="Welcome to Scorecard">
         <HeaderLabel label="Owner" value="Team X" />
         <HeaderLabel label="Lifecycle" value="Alpha" />
       </Header>
       <Content>
-        <ContentHeader title="Plugin title">
+        <ContentHeader title="Akrivis - Readiness Score">
           <SupportButton>A plugin for scorecards</SupportButton>
         </ContentHeader>
         <Grid container spacing={3} direction="column">

--- a/plugins/rules/src/index.ts
+++ b/plugins/rules/src/index.ts
@@ -1,2 +1,2 @@
 export { rulesPlugin, RulesPage } from './plugin';
-export { ScoreCardsView } from './components/Cards/ScoreCardsView';
+export { CardsView } from './components/Cards/CardsView';

--- a/plugins/rules/src/useRulesClient.ts
+++ b/plugins/rules/src/useRulesClient.ts
@@ -3,11 +3,11 @@ import { useEffect, useState } from 'react';
 import { useApi } from '@backstage/core-plugin-api';
 
 import { scoreCardApiRef } from './api/api';
-import { ScoreCardResult } from './api/types';
+import { CardResult } from './api/types';
 
 export const useScoreCards = () => {
   const [loading, setLoading] = useState<boolean>(true);
-  const [value, setValue] = useState<ScoreCardResult[]>([]);
+  const [value, setValue] = useState<CardResult[]>([]);
   const [error, setError] = useState<boolean>(false);
   const scoreCardApi = useApi(scoreCardApiRef);
   const getObjects = async () => {


### PR DESCRIPTION
https://github.com/kiegroup/akrivis/issues/27

Expands the concept of the Card from just showing Score to also showing Reporting.
The wire diagram activates when the Result of the Card is a list or a map.

![image](https://github.com/user-attachments/assets/6ec4ae20-be09-421e-8a4f-37f47341c4c8)
